### PR TITLE
230102 이경훈 백준 17427 약수의 합 2 풀이

### DIFF
--- a/BOJ/2301/02/이경훈_17425_약수의 합.py
+++ b/BOJ/2301/02/이경훈_17425_약수의 합.py
@@ -1,0 +1,24 @@
+import sys
+
+input = sys.stdin.readline
+
+MAX = 1000000 # 최대값 설정
+
+f = [1] * (MAX+1) # f(x)의 값
+
+g = [0] * (MAX+1) # g(x)의 값
+
+for i in range(2, MAX+1):
+  for j in range(i, MAX+1, i): # 에라토스테네스의 채를 이용
+    f[j] += i
+
+for i in range(1, MAX+1):
+  g[i] = g[i-1] + f[i] # g[i]의 누적 값을 구함
+
+n = int(input())
+ans = []
+
+for i in range(n):
+  n = int(input())
+  ans.append(g[n])
+print('\n'.join(map(str, ans))) # 그냥 매번 print 하는 것 보다 이렇게 append해서 한번에 print 해주는게 훨씬 빠름

--- a/BOJ/2301/02/이경훈_17427_약수의 합 2.py
+++ b/BOJ/2301/02/이경훈_17427_약수의 합 2.py
@@ -1,0 +1,6 @@
+n = int(input())
+ans = 0
+
+for i in range(1, n+1): # 1부터 n까지
+  ans += i * (n // i) # i와 n을 i로 나눈 몫을 곱해서 계속 더한다
+print(ans)


### PR DESCRIPTION
- [백준 4375번 문제](https://www.acmicpc.net/problem/17427)

- 내용: 
두 자연수 A와 B가 있을 때, A = BC를 만족하는 자연수 C를 A의 약수라고 한다. 예를 들어, 2의 약수는 1, 2가 있고, 24의 약수는 1, 2, 3, 4, 6, 8, 12, 24가 있다. 자연수 A의 약수의 합은 A의 모든 약수를 더한 값이고, f(A)로 표현한다. x보다 작거나 같은 모든 자연수 y의 f(y)값을 더한 값은 g(x)로 표현한다.
자연수 N이 주어졌을 때, g(N)을 구해보자.

- 풀이:
규칙을 찾아낸다.
규칙은 아래와 같다.

f(1) = 1

f(2) = 1 + 2

f(3) = 1 + 3

f(4) = 1 + 2 + 4

f(5) = 1 + 5

f(6) = 1 + 2 + 3 + 6
---------------------------------------
g(4) = 1*4 + 2*2 + 3*1 + 4*1

g(5) = 1*5 + 2*2 + 3*1 + 4*1 + 5*1

g(6) = 1*6 + 2*3 + 3*2 + 4*1 + 5*1 + 6*1